### PR TITLE
Potential fix for code scanning alert no. 18: Server-side request forgery

### DIFF
--- a/services/cors-proxy.js
+++ b/services/cors-proxy.js
@@ -5,7 +5,14 @@
  */
 
 const axios = require('axios');
+const { URL } = require('url');
 
+// Define allow-list of permitted hostnames
+const ALLOWED_HOSTNAMES = [
+  'api.example.com',
+  'service.example.net',
+  // Add more hostnames as needed
+];
 module.exports = (req, res) => {
   // Apply allow-all response headers
   res.header('Access-Control-Allow-Origin', '*');
@@ -23,8 +30,20 @@ module.exports = (req, res) => {
   // Get desired URL, from Target-URL header
   const targetURL = req.header('Target-URL');
   if (!targetURL) {
-    res.status(500).send({ error: 'There is no Target-Endpoint header in the request' });
+    res.status(400).send({ error: 'Missing Target-URL header in the request' });
     return;
+  let hostname;
+  try {
+    const parsed = new URL(targetURL);
+    hostname = parsed.hostname;
+  } catch (e) {
+    res.status(400).send({ error: 'Invalid Target-URL format' });
+    return;
+  }
+  if (!ALLOWED_HOSTNAMES.includes(hostname)) {
+    res.status(403).send({ error: 'Target hostname is not allowed' });
+    return;
+  }
   }
   // Apply any custom headers, if needed
   const headers = req.header('CustomHeaders') ? JSON.parse(req.header('CustomHeaders')) : {};


### PR DESCRIPTION
Potential fix for [https://github.com/SeanStaffiery/dashy/security/code-scanning/18](https://github.com/SeanStaffiery/dashy/security/code-scanning/18)

To fix the SSRF vulnerability, you must restrict which URLs can be targeted by this proxy. The standard approach is to define an allow-list (whitelist) of permitted hostnames or origins. The fix should only allow requests if the parsed hostname matches an entry in a trusted list (e.g., a list of allowed API service domains you expect the frontend to call via this proxy). If the requested URL does not match, respond with an error.

Edit the code to:

- Introduce an allow-list of permitted hostnames or base URLs near the top of the file.
- Parse `targetURL` (the value from `Target-URL`) and extract only the hostname.
- Check the hostname of the parsed URL against the allow-list before making any HTTP request.
- Respond with a 400/403 error if the hostname is not allowed, and skip making the request.
- Add any required module imports (such as for URL parsing) **only if necessary**.

All changes should be within `services/cors-proxy.js`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
