### PR TITLE
Potential fix for code scanning alert no. 44: Server-side request forgery

### DIFF
--- a/services/cors-proxy.js
+++ b/services/cors-proxy.js
@@ -120,9 +120,14 @@ module.exports = (req, res) => {
     }
 
     // Prepare the request
+    // Explicitly reconstruct a safe URL (never trust origin/protocol/port from user)
+    const safeUrl =
+      'https://' + hostname +
+      parsed.pathname +
+      parsed.search;
     const requestConfig = {
       method: req.method,
-      url: parsed.origin + parsed.pathname + parsed.search,
+      url: safeUrl,
       data: req.body,
       headers,
     };


### PR DESCRIPTION
Potential fix for [https://github.com/SeanStaffiery/dashy/security/code-scanning/44](https://github.com/SeanStaffiery/dashy/security/code-scanning/44)

To ensure no SSRF vulnerabilities remain, reconstruct the outbound request URL strictly from validated components rather than using user input more broadly.  
- Only allow the user to select an allow-listed hostname (already enforced), and only allow known-safe path/query segments.
- Explicitly define the request protocol as `https://` (never from user input), and do not allow port override.
- Rebuild the outbound URL string as `https://<hostname><pathname><search>`, using values from the parsed and validated URL object.
- Optionally, further validate `pathname` and `search` for unexpected characters or encoding quirks.
- Confirm that the fix only permits requests to allow-listed hosts, on port 443, using only validated paths/queries (no encoded path traversal, fragments, or userinfo).
- The edit is needed in the region preparing `requestConfig.url` (line 125 in `services/cors-proxy.js`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
